### PR TITLE
Add test cases for the single-file tests

### DIFF
--- a/src/docker/naclruntime/Dockerfile
+++ b/src/docker/naclruntime/Dockerfile
@@ -16,41 +16,14 @@ USER lind
 WORKDIR /home/lind/lind_project/
 RUN git pull -t -j8
 RUN for t in nacl repy install; do ./src/mklind -q "$t"; done
-RUN x86_64-nacl-gcc "tests/test_cases/cpuid.c" -o "lind/repy/repy/cpuid"
-RUN x86_64-nacl-gcc "tests/test_cases/dup2.c" -o "lind/repy/repy/dup2"
-RUN x86_64-nacl-gcc "tests/test_cases/dup.c" -o "lind/repy/repy/dup"
-RUN x86_64-nacl-gcc "tests/test_cases/fgets.c" -o "lind/repy/repy/fgets"
-RUN x86_64-nacl-gcc "tests/test_cases/fork.c" -o "lind/repy/repy/fork"
-RUN x86_64-nacl-gcc "tests/test_cases/fork_simple.c" -o "lind/repy/repy/fork_simple"
-RUN x86_64-nacl-gcc "tests/test_cases/getpid.c" -o "lind/repy/repy/getpid"
-RUN x86_64-nacl-gcc "tests/test_cases/hello.c" -o "lind/repy/repy/hello"
-RUN x86_64-nacl-gcc "tests/test_cases/mprotec.c" -o "lind/repy/repy/mprotec"
-RUN x86_64-nacl-gcc "tests/test_cases/read_input.c" -o "lind/repy/repy/read_input"
-RUN x86_64-nacl-gcc "tests/test_cases/segfault.c" -o "lind/repy/repy/segfault"
-RUN x86_64-nacl-gcc "tests/test_cases/sysconf.c" -o "lind/repy/repy/sysconf"
-RUN x86_64-nacl-gcc "tests/test_cases/template.c" -o "lind/repy/repy/template"
-RUN x86_64-nacl-gcc "tests/test_cases/write.c" -o "lind/repy/repy/write"
+RUN for c in cpuid dup2 dup fgets fork fork_simple getpid hello mprotec read_input segfault sysconf template write; do x86_64-nacl-gcc "tests/test_cases/$c.c" -o "lind/repy/repy/$c"; done
 WORKDIR /home/lind/lind_project/tests/test_cases/bash/
 RUN ./bootstrap_nacl --prefix="/home/lind/lind_project/lind/repy/repy"
 RUN make install
 
 WORKDIR /home/lind/lind_project/lind/repy/repy/
 RUN for f in ./bin/ ./lib/ ./share/ ./cpuid ./dup2 ./dup ./fgets ./fork ./fork_simple ./getpid ./hello ./mprotec ./read ./read_input ./segfault ./sysconf ./template ./write ./.bashrc ./.bash_logout ./.bash_profile; do lindfs cp "$f"; done
-RUN script -qfc "$(printf '%q ' lind /cpuid)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /dup2)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /dup)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /fgets)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /fork)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /fork_simple)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /getpid)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /hello)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /mprotec)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /read_input)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /segfault)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /sysconf)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /template)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /write)" /dev/null
-RUN script -qfc "$(printf '%q ' lind /bin/bash --version)" /dev/null
+RUN for a in /cpuid /dup2 /dup /fgets /fork /fork_simple /getpid /hello /mprotec /read_input /segfault /sysconf /template /write "/bin/bash --version"; do script -qfc "$(printf '%q ' lind $a)" /dev/null; done
 
 # default to running test cases then a shell if no arguments are passed to `docker run`
 CMD bash -c 'lind /cpuid; lind /dup2; lind /dup; lind /fgets; lind /fork; lind /fork_simple; lind /getpid; lind /hello; lind /mprotec; lind /read_input; lind /segfault; lind /sysconf; lind /template; lind /write; lind /bin/bash --version; exec bash'

--- a/src/docker/naclruntime/Dockerfile
+++ b/src/docker/naclruntime/Dockerfile
@@ -11,19 +11,29 @@ ENV PATH "/home/lind/lind_project:$PATH"
 ENV PATH "/home/lind/lind_project/lind/repy/bin:$PATH"
 ENV PATH "/home/lind/lind_project/lind/repy/sdk/toolchain/linux_x86_glibc/bin:$PATH"
 
+ENV TEST_CASES "cpuid dup2 dup exec fgets fork fork_simple getpid hello mprotec pipe read read_input segfault stat sysconf template write"
+
 USER lind
 
 WORKDIR /home/lind/lind_project/
 RUN git pull -t -j8
 RUN for t in nacl repy install; do ./src/mklind -q "$t"; done
-RUN for c in cpuid dup2 dup exec fgets fork fork_simple getpid hello mprotec pipe read read_input segfault stat sysconf template write; do x86_64-nacl-gcc -std=c99 "tests/test_cases/$c.c" -o "lind/repy/repy/$c"; done
+RUN mkdir -p lind/repy/repy/tests
+RUN for c in $TEST_CASES; do x86_64-nacl-gcc -std=c99 "tests/test_cases/$c.c" -o "lind/repy/repy/tests/$c"; done
 WORKDIR /home/lind/lind_project/tests/test_cases/bash/
 RUN ./bootstrap_nacl --prefix="/home/lind/lind_project/lind/repy/repy"
 RUN make install
 
+# Set up the sandbox and copy bash
 WORKDIR /home/lind/lind_project/lind/repy/repy/
-RUN for f in ./bin/ ./lib/ ./share/ ./cpuid ./dup2 ./dup ./exec ./fgets ./fork ./fork_simple ./getpid ./hello ./mprotec ./pipe ./read ./read_input ./segfault ./stat ./sysconf ./template ./write ./.bashrc ./.bash_logout ./.bash_profile; do lindfs cp "$f"; done
-RUN for a in /cpuid /dup2 /dup /fgets /fork /fork_simple /getpid /hello /mprotec /read_input /segfault /sysconf /template /write "/bin/bash --version"; do script -qfc "$(printf '%q ' lind $a)" /dev/null; done
+RUN for f in ./bin/ ./lib/ ./share/ ./.bashrc ./.bash_logout ./.bash_profile; do lindfs cp "$f"; done
+
+# Copy and run the single-file tests
+RUN for f in $TEST_CASES; do lindfs cp "./tests/$f"; done
+RUN for a in $TEST_CASES; do script -qfc "$(printf '%q ' lind /tests/$a)" /dev/null; done
+
+# Run the bash test
+RUN script -qfc "$(printf '%q ' lind /bin/bash --version)" /dev/null
 
 # default to running test cases then a shell if no arguments are passed to `docker run`
-CMD bash -c 'lind /cpuid; lind /dup2; lind /dup; lind /exec; lind /fgets; lind /fork; lind /fork_simple; lind /getpid; lind /hello; lind /mprotec; lind /pipe; lind /read; lind /read_input; lind /segfault; lind /stat; lind /sysconf; lind /template; lind /write; lind /bin/bash --version; exec bash'
+CMD bash -c 'for f in $TEST_CASES; do lind /tests/$f; done; lind /bin/bash --version; exec bash'

--- a/src/docker/naclruntime/Dockerfile
+++ b/src/docker/naclruntime/Dockerfile
@@ -16,17 +16,41 @@ USER lind
 WORKDIR /home/lind/lind_project/
 RUN git pull -t -j8
 RUN for t in nacl repy install; do ./src/mklind -q "$t"; done
+RUN x86_64-nacl-gcc "tests/test_cases/cpuid.c" -o "lind/repy/repy/cpuid"
+RUN x86_64-nacl-gcc "tests/test_cases/dup2.c" -o "lind/repy/repy/dup2"
+RUN x86_64-nacl-gcc "tests/test_cases/dup.c" -o "lind/repy/repy/dup"
+RUN x86_64-nacl-gcc "tests/test_cases/fgets.c" -o "lind/repy/repy/fgets"
 RUN x86_64-nacl-gcc "tests/test_cases/fork.c" -o "lind/repy/repy/fork"
+RUN x86_64-nacl-gcc "tests/test_cases/fork_simple.c" -o "lind/repy/repy/fork_simple"
+RUN x86_64-nacl-gcc "tests/test_cases/getpid.c" -o "lind/repy/repy/getpid"
 RUN x86_64-nacl-gcc "tests/test_cases/hello.c" -o "lind/repy/repy/hello"
+RUN x86_64-nacl-gcc "tests/test_cases/mprotec.c" -o "lind/repy/repy/mprotec"
+RUN x86_64-nacl-gcc "tests/test_cases/read_input.c" -o "lind/repy/repy/read_input"
+RUN x86_64-nacl-gcc "tests/test_cases/segfault.c" -o "lind/repy/repy/segfault"
+RUN x86_64-nacl-gcc "tests/test_cases/sysconf.c" -o "lind/repy/repy/sysconf"
+RUN x86_64-nacl-gcc "tests/test_cases/template.c" -o "lind/repy/repy/template"
+RUN x86_64-nacl-gcc "tests/test_cases/write.c" -o "lind/repy/repy/write"
 WORKDIR /home/lind/lind_project/tests/test_cases/bash/
 RUN ./bootstrap_nacl --prefix="/home/lind/lind_project/lind/repy/repy"
 RUN make install
 
 WORKDIR /home/lind/lind_project/lind/repy/repy/
-RUN for f in ./bin/ ./lib/ ./share/ ./fork ./hello ./.bashrc ./.bash_logout ./.bash_profile; do lindfs cp "$f"; done
+RUN for f in ./bin/ ./lib/ ./share/ ./cpuid ./dup2 ./dup ./fgets ./fork ./fork_simple ./getpid ./hello ./mprotec ./read ./read_input ./segfault ./sysconf ./template ./write ./.bashrc ./.bash_logout ./.bash_profile; do lindfs cp "$f"; done
+RUN script -qfc "$(printf '%q ' lind /cpuid)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /dup2)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /dup)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /fgets)" /dev/null
 RUN script -qfc "$(printf '%q ' lind /fork)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /fork_simple)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /getpid)" /dev/null
 RUN script -qfc "$(printf '%q ' lind /hello)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /mprotec)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /read_input)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /segfault)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /sysconf)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /template)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /write)" /dev/null
 RUN script -qfc "$(printf '%q ' lind /bin/bash --version)" /dev/null
 
 # default to running test cases then a shell if no arguments are passed to `docker run`
-CMD bash -c 'lind /fork; lind /hello; lind /bin/bash --version; exec bash'
+CMD bash -c 'lind /cpuid; lind /dup2; lind /dup; lind /fgets; lind /fork; lind /fork_simple; lind /getpid; lind /hello; lind /mprotec; lind /read_input; lind /segfault; lind /sysconf; lind /template; lind /write; lind /bin/bash --version; exec bash'

--- a/src/docker/naclruntime/Dockerfile
+++ b/src/docker/naclruntime/Dockerfile
@@ -16,14 +16,14 @@ USER lind
 WORKDIR /home/lind/lind_project/
 RUN git pull -t -j8
 RUN for t in nacl repy install; do ./src/mklind -q "$t"; done
-RUN for c in cpuid dup2 dup fgets fork fork_simple getpid hello mprotec read_input segfault sysconf template write; do x86_64-nacl-gcc "tests/test_cases/$c.c" -o "lind/repy/repy/$c"; done
+RUN for c in cpuid dup2 dup exec fgets fork fork_simple getpid hello mprotec pipe read read_input segfault stat sysconf template write; do x86_64-nacl-gcc -std=c99 "tests/test_cases/$c.c" -o "lind/repy/repy/$c"; done
 WORKDIR /home/lind/lind_project/tests/test_cases/bash/
 RUN ./bootstrap_nacl --prefix="/home/lind/lind_project/lind/repy/repy"
 RUN make install
 
 WORKDIR /home/lind/lind_project/lind/repy/repy/
-RUN for f in ./bin/ ./lib/ ./share/ ./cpuid ./dup2 ./dup ./fgets ./fork ./fork_simple ./getpid ./hello ./mprotec ./read ./read_input ./segfault ./sysconf ./template ./write ./.bashrc ./.bash_logout ./.bash_profile; do lindfs cp "$f"; done
+RUN for f in ./bin/ ./lib/ ./share/ ./cpuid ./dup2 ./dup ./exec ./fgets ./fork ./fork_simple ./getpid ./hello ./mprotec ./pipe ./read ./read_input ./segfault ./stat ./sysconf ./template ./write ./.bashrc ./.bash_logout ./.bash_profile; do lindfs cp "$f"; done
 RUN for a in /cpuid /dup2 /dup /fgets /fork /fork_simple /getpid /hello /mprotec /read_input /segfault /sysconf /template /write "/bin/bash --version"; do script -qfc "$(printf '%q ' lind $a)" /dev/null; done
 
 # default to running test cases then a shell if no arguments are passed to `docker run`
-CMD bash -c 'lind /cpuid; lind /dup2; lind /dup; lind /fgets; lind /fork; lind /fork_simple; lind /getpid; lind /hello; lind /mprotec; lind /read_input; lind /segfault; lind /sysconf; lind /template; lind /write; lind /bin/bash --version; exec bash'
+CMD bash -c 'lind /cpuid; lind /dup2; lind /dup; lind /exec; lind /fgets; lind /fork; lind /fork_simple; lind /getpid; lind /hello; lind /mprotec; lind /pipe; lind /read; lind /read_input; lind /segfault; lind /stat; lind /sysconf; lind /template; lind /write; lind /bin/bash --version; exec bash'


### PR DESCRIPTION
This includes all the tests with C source files, but doesn't include the .S files (I don't know if those are GCC output or actual code)?

This patch also enables C99 mode, otherwise some tests (exec, pipe, read, and stat) won't compile.