### PR TITLE
Timeinfo

### DIFF
--- a/src/scripts/lind
+++ b/src/scripts/lind
@@ -9,7 +9,7 @@ print_arg_str=''
 usage="usage: ${0##*/} -[fghstvx] [-a <sel_ldr extra args>] [-l <blob library>] -- [nacl_file] [args]"
 
 # check for xtrace flag
-while getopts :a:l:dfghsvx opt; do
+while getopts :a:l:dfghstvx opt; do
 	case "$opt" in
 	# append custom args
 	a)

--- a/src/scripts/lind
+++ b/src/scripts/lind
@@ -6,7 +6,7 @@ ldr_cmd=('sel_ldr')
 ldr_args=()
 gdb_arg_str=('')
 print_arg_str=''
-usage="usage: ${0##*/} -[fghsvx] [-a <sel_ldr extra args>] [-l <blob library>] -- [nacl_file] [args]"
+usage="usage: ${0##*/} -[fghstvx] [-a <sel_ldr extra args>] [-l <blob library>] -- [nacl_file] [args]"
 
 # check for xtrace flag
 while getopts :a:l:dfghsvx opt; do
@@ -32,6 +32,9 @@ while getopts :a:l:dfghsvx opt; do
 	# increase verbosity
 	v)
 		extra_args+=('-v');;
+	# add timing
+	t)
+		extra_args+=('-t');;
 	# use xtrace
 	x)
 		set -o xtrace;;

--- a/src/scripts/lind
+++ b/src/scripts/lind
@@ -34,7 +34,7 @@ while getopts :a:l:dfghsvx opt; do
 		extra_args+=('-v');;
 	# add timing
 	t)
-		extra_args+=('-t');;
+		[[ "${extra_args[*]}" != *-S* ]] && extra_args+=('-t');;
 	# use xtrace
 	x)
 		set -o xtrace;;

--- a/tests/pipeline-tests/bash-pipelines/cast
+++ b/tests/pipeline-tests/bash-pipelines/cast
@@ -1,0 +1,19 @@
+Jeff Bridges as Jeffrey "The Dude" Lebowski. Bridges had heard or was told by the Coen brothers that they had written a screenplay for him.[9]:27
+John Goodman as Walter Sobchak; a Vietnam veteran and bowling partner and friend of "The Dude." Walter was based, in part, on screenwriter and director John Milius.[10]:189
+Julianne Moore as Maude Lebowski; Jeffrey "The Big" Lebowski's daughter, a feminist and an avant-garde artist.
+Steve Buscemi as Theodore Donald "Donny" Kerabatsos; a bowling partner and friend of "The Dude." Walter's repeated response, "Shut the fuck up, Donny!" is a reference to Fargo, in which Buscemi's character was constantly talking and interrupting conversations when he is not paying attention to the story.[11]
+David Huddleston as Jeffrey "The Big" Lebowski; a millionaire philanthropist for whom "The Dude" is mistaken.
+Philip Seymour Hoffman as Brandt; Jeffrey "The Big" Lebowski's executive assistant
+Tara Reid as Bunny Lebowski; Jeffrey "The Big" Lebowski's blonde 20s-something trophy wife and former porn video performer (“Log Jammin’”) for Jackie Treehorn Productions. According to Reid, Charlize Theron also tried out for the role.[9]:72
+Philip Moon as Woo; a Jackie Treehorn thug
+Mark Pellegrino as the Blond Treehorn thug
+Peter Stormare, Torsten Voges, and Flea as Uli Kunkel/Karl Hungus, Franz, and Kieffer, the German nihilists; Uli originated on the set of Fargo between Ethan Coen and Stormare, who often spoke in a mock German accent.[9]:57
+Jimmie Dale Gilmore as Smokey; a hippie bowler in the league whom Walter threatens at gunpoint over an attempt to mark his frame an eight despite letting his foot move over the alley line
+Jack Kehler as Marty; The Dude's landlord, who is also a performance artist
+John Turturro as Jesus Quintana. The Coen brothers let Turturro come up with a lot of his own ideas for the character, like towel-shining the bowling ball and the scene where he dances backward from his bowling alley line, which he says was inspired by Muhammad Ali.[9]:44
+David Thewlis as Knox Harrington, an avant-garde videographer-friend of Maude Lebowski
+Sam Elliott as The Stranger, a smooth-talking urban cowboy who also serves as the narrator of the film
+Ben Gazzara as big-time porn video producer Jackie Treehorn, to whom Bunny Lebowski owes money
+Jon Polito as Da Fino, a private dick who mistakes the Dude for a "brother shamus", hired by Bunny's family to return her to them
+Leon Russom as the Malibu police chief
+Aimee Mann as Nihilist Woman/Franz's Girlfriend who donates her amputated green nail-polished little toe (proof of Bunny Lebowski's kidnapping).

--- a/tests/pipeline-tests/bash-pipelines/catgrep
+++ b/tests/pipeline-tests/bash-pipelines/catgrep
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cat cast | grep "Lebowski" 

--- a/tests/pipeline-tests/bash-pipelines/catgrepwc
+++ b/tests/pipeline-tests/bash-pipelines/catgrepwc
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cat cast | grep "Lebowski" | wc

--- a/tests/pipeline-tests/bash-pipelines/catwc
+++ b/tests/pipeline-tests/bash-pipelines/catwc
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cat lebowski | wc

--- a/tests/pipeline-tests/bash-pipelines/lebowski
+++ b/tests/pipeline-tests/bash-pipelines/lebowski
@@ -1,0 +1,1 @@
+Wait... let me just explain something to you. I am not Mr. Lebowski. You're Mr. Lebowski. I'm "The Dude". So that's what you call me, you know. That, or His Dudeness, or Duder, or El Duderino if you're not into the whole brevity thing.

--- a/tests/pipeline-tests/bash-pipelines/lscat
+++ b/tests/pipeline-tests/bash-pipelines/lscat
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ls | cat

--- a/tests/pipeline-tests/bash-pipelines/lscatwc
+++ b/tests/pipeline-tests/bash-pipelines/lscatwc
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ls | cat | wc


### PR DESCRIPTION
Adds an explicit flag for `lind` to get time information.

Added some pipeline base tests.