### PR TITLE
Fixed bugs in lindprompt.

### DIFF
--- a/src/scripts/lindprompt
+++ b/src/scripts/lindprompt
@@ -45,7 +45,7 @@ while true; do
           then read -r -p "File is not an nexe file. Try to run anyway? [y/N]" response
           case "$response" in
               [yY][eE][sS]|[yY])
-                  $LIND_ROOT/lind/repy/bin/lind ${myarr[1]};
+                  $LIND_ROOT/lind/repy/bin/lind ${myarr[@]:1};
                   continue;
                   ;;
               *)
@@ -53,13 +53,13 @@ while true; do
                   ;;
           esac;
       fi
-      $LIND_ROOT/lind/repy/bin/lind ${myarr[1]};
+      $LIND_ROOT/lind/repy/bin/lind ${myarr[@]:1};
       ;;
     exit|quit)
       exit
       ;;
     *)
-      if result=$(${myarr[@]}); then
+      if result=$(eval ${myarr[@]}); then
         printf "$result\n"
       else
         echo "Command not found. Try help for information about commands"


### PR DESCRIPTION
Fixed lindprompt's inability to read command-line arguments for the programs to be run on lind.

Lindprompt's batch-fallback was flawed since it did not run pipes properly. Fixed it by changing $(${myarr[@]}) to $(eval ${myarr[@]}). - must be checked for potential security problems by eval

It must be noted that this second fix was for batch-fallback only.  lindsh entries having valid lindprompt commands will still only run the given command and not work with pipes in the current implementation of lindsh (will treat them as non-valid extra arguments). $lindprompt must be used if the result is needed to be consumed by another command.