### PR TITLE
Add environment option to the Lind script

### DIFF
--- a/src/scripts/lind
+++ b/src/scripts/lind
@@ -33,7 +33,7 @@ while getopts :a:l:e:dfghpstvx opt; do
 	s)
 		[[ "${extra_args[*]}" != *-S* ]] && extra_args+=('-S');;
 	# user perf mode
-	t)
+	p)
 		[[ "${extra_args[*]}" != *-p* ]] && extra_args+=('-p');;
 	# increase verbosity
 	v)

--- a/src/scripts/lind
+++ b/src/scripts/lind
@@ -6,10 +6,10 @@ ldr_cmd=('sel_ldr')
 ldr_args=()
 gdb_arg_str=('')
 print_arg_str=''
-usage="usage: ${0##*/} -[fghstvx] [-a <sel_ldr extra args>] [-l <blob library>] [-e <environment variable>]-- [nacl_file] [args]"
+usage="usage: ${0##*/} -[fghpstvx] [-a <sel_ldr extra args>] [-l <blob library>] [-e <environment variable>]-- [nacl_file] [args]"
 
 # check for xtrace flag
-while getopts :a:l:e:dfghstvx opt; do
+while getopts :a:l:e:dfghpstvx opt; do
 	case "$opt" in
 	# append custom args
 	a)
@@ -32,6 +32,9 @@ while getopts :a:l:e:dfghstvx opt; do
 	# enable signal handling
 	s)
 		[[ "${extra_args[*]}" != *-S* ]] && extra_args+=('-S');;
+	# user perf mode
+	t)
+		[[ "${extra_args[*]}" != *-p* ]] && extra_args+=('-p');;
 	# increase verbosity
 	v)
 		extra_args+=('-v');;

--- a/src/scripts/lind
+++ b/src/scripts/lind
@@ -6,10 +6,10 @@ ldr_cmd=('sel_ldr')
 ldr_args=()
 gdb_arg_str=('')
 print_arg_str=''
-usage="usage: ${0##*/} -[fghstvx] [-a <sel_ldr extra args>] [-l <blob library>] -- [nacl_file] [args]"
+usage="usage: ${0##*/} -[fghstvx] [-a <sel_ldr extra args>] [-l <blob library>] [-e <environment variable>]-- [nacl_file] [args]"
 
 # check for xtrace flag
-while getopts :a:l:dfghstvx opt; do
+while getopts :a:l:e:dfghstvx opt; do
 	case "$opt" in
 	# append custom args
 	a)
@@ -17,6 +17,9 @@ while getopts :a:l:dfghstvx opt; do
 	# enable gdb debug hook
 	d)
 		[[ "${extra_args[*]}" != *-g* ]] && extra_args+=('-g');;
+	# add environment variable
+	e)
+		extra_args+=('-E' "$OPTARG");;
 	# enable fuzz testing (quit after leading nacl app)
 	f)
 		[[ "${extra_args[*]}" != *-F* ]] && extra_args+=('-F');;
@@ -34,7 +37,7 @@ while getopts :a:l:dfghstvx opt; do
 		extra_args+=('-v');;
 	# add timing
 	t)
-		[[ "${extra_args[*]}" != *-S* ]] && extra_args+=('-t');;
+		[[ "${extra_args[*]}" != *-t* ]] && extra_args+=('-t');;
 	# use xtrace
 	x)
 		set -o xtrace;;


### PR DESCRIPTION
Adds `-e` flag to the lind script to run program with environment variable set. For now only one variable can be sent at a time, more variables can be set by running a bash script through Lind and setting them in the script. 

In the future this could be expanded for multiple variables by adding changes to `sel_main`