### PR TITLE
Fix Implicit Declarations warning in pread_pwrite.c

### DIFF
--- a/tests/test_cases/pread_pwrite.c
+++ b/tests/test_cases/pread_pwrite.c
@@ -1,4 +1,5 @@
  // using code from from https://stackoverflow.com/questions/41362754/reading-with-pread-and-writing-with-pwrite-in-c
+#define _XOPEN_SOURCE 500
 
 #include <fcntl.h>
 #include <stdio.h>


### PR DESCRIPTION
This PR fixes the warning when compiling `tests/test_cases/pread_pwrite.c`. A macro is added to inform the compiler to include extra extensions.

A better explanation of the macro: https://stackoverflow.com/a/5724485 