### PR TITLE
Net shutdown test case

### DIFF
--- a/tests/test_cases/nondet.txt
+++ b/tests/test_cases/nondet.txt
@@ -20,3 +20,5 @@ serverclient.c
 socketselect.c
 fork_simple.c
 socketepoll.c
+shutdown.c
+shutdown_fork.c

--- a/tests/test_cases/serverclient.c
+++ b/tests/test_cases/serverclient.c
@@ -89,5 +89,6 @@ int main() {
     pthread_create(&clientthread1, NULL, client, NULL);
     pthread_join(clientthread1, NULL);
     pthread_join(serverthread, NULL);
+    pthread_barrier_destroy(&barrier);
     return 0;
 }

--- a/tests/test_cases/shutdown.c
+++ b/tests/test_cases/shutdown.c
@@ -1,3 +1,5 @@
+/* A multithreaded testcase for shutdown() */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/test_cases/shutdown.c
+++ b/tests/test_cases/shutdown.c
@@ -1,0 +1,110 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+// Adapted from https://www.geeksforgeeks.org/socket-programming-cc/
+void *ponger(void *vargp) {
+	int server_fd, new_socket, valread, finished;
+	int opt = 1;
+	int counter;
+	struct sockaddr_in address;
+	int addrlen = sizeof(address);
+	char buffer[1024];
+
+	if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+		printf("socket failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt))) {
+		printf("setsockopt\n");
+		exit(EXIT_FAILURE);
+	}
+
+	address.sin_family = AF_INET;
+	address.sin_addr.s_addr = INADDR_ANY;
+	address.sin_port = htons(5000);
+
+	if (bind(server_fd, (struct sockaddr*)&address, sizeof(address)) < 0) {
+		printf("bind failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (listen(server_fd, 3) < 0) {
+		printf("listen\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if ((new_socket = accept(server_fd, (struct sockaddr*)&address, (socklen_t*)&addrlen)) < 0) {
+		printf("accept\n");
+		exit(EXIT_FAILURE);
+	}
+
+	valread = read(new_socket, buffer, 1024);
+	printf("ponger: %s\n", buffer);
+	sprintf(buffer, "%d", atoi(buffer)+1);
+
+	send(new_socket, buffer, strlen(buffer), 0);
+	printf("ponger: %s\n", buffer);
+
+	close(new_socket);
+	shutdown(server_fd, SHUT_RDWR);
+}
+
+void *pinger(void *vargp) {
+	int sock = 0, valread, client_fd;
+	int counter = 0;
+	struct sockaddr_in serv_addr;
+	char buffer[1024];
+
+	if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+	    printf("client socket creation error\n");
+	    exit(EXIT_FAILURE);
+	}
+
+	serv_addr.sin_family = AF_INET;
+	serv_addr.sin_port = htons(5000);
+
+	if (inet_pton(AF_INET, "127.0.0.1", &serv_addr.sin_addr) <= 0) {
+	    printf("Invalid address/ Address not supported\n");
+	    exit(EXIT_FAILURE);
+	}
+
+	if ((client_fd = connect(sock, (struct sockaddr*)&serv_addr, sizeof(serv_addr))) < 0) {
+	    printf("Connection Failed\n");
+	    exit(EXIT_FAILURE);
+	}
+
+	sprintf(buffer, "%d", ++counter);
+	printf("client: %s\n", buffer);
+
+	send(sock, buffer, strlen(buffer), 0);
+	valread = read(sock, buffer, 1024);
+
+	counter = atoi(buffer);
+	printf("client: %s\n", buffer);
+
+	close(client_fd);
+}
+
+int main( int argc, char *argv[] ) {
+	pthread_t ponger_id, pinger_id;
+	
+	printf("Threads start\n");
+
+	pthread_create(&ponger_id, NULL, ponger, NULL);
+	pthread_create(&pinger_id, NULL, pinger, NULL);
+
+	pthread_join(ponger_id, NULL);
+	pthread_join(pinger_id, NULL);
+
+	printf("Threads end\n");
+
+	return 0;
+}

--- a/tests/test_cases/shutdown.c
+++ b/tests/test_cases/shutdown.c
@@ -11,6 +11,8 @@
 #include <unistd.h>
 #include <errno.h>
 
+pthread_barrier_t barrier;
+
 const int NUM_OF_PINGER = 2;
 const int NUM_OF_PINGPONG = 10;
 const int BUFFER_SIZE = 32;
@@ -62,6 +64,8 @@ void *ponger(void *vargp) {
 		exit(EXIT_FAILURE);
 	}
 
+	pthread_barrier_wait(&barrier);
+
 	// Bounce and increment numbers between pingers
 	for (int i = 0; i < NUM_OF_PINGER * NUM_OF_PINGPONG; ++i) {
 		// Establish a new connection
@@ -98,7 +102,7 @@ void *pinger(void *vargp) {
 	struct sockaddr_in serv_addr;
 	char buffer[BUFFER_SIZE];
 
-	sleep(1); // Wait for ponger to setup its socket
+	pthread_barrier_wait(&barrier);
 
 	// Loop a few times to try trigger race conditions
 	for (int i = 0; i < NUM_OF_PINGPONG; ++i) {
@@ -160,6 +164,8 @@ int main( int argc, char *argv[] ) {
 	for (int i = 0; i < NUM_OF_PINGER; ++i) {
 		pinger_id_natural[i] = i;
 	}
+
+	pthread_barrier_init(&barrier, NULL, NUM_OF_PINGER+1);
 	
 	printf("Starting Ponger\n");
 	fflush(stdout);
@@ -178,6 +184,8 @@ int main( int argc, char *argv[] ) {
 
 	printf("Threads end\n");
 	fflush(stdout);
+
+	pthread_barrier_destroy(&barrier);
 
 	return 0;
 }

--- a/tests/test_cases/shutdown.py
+++ b/tests/test_cases/shutdown.py
@@ -5,6 +5,16 @@ import sys
 lind_result = sys.argv[1]
 host_result = sys.argv[2]
 
+# Extract numbers sent and received by ponger and pingers
+lind_numbers = [int(line.split(':')[1]) for line in lind_result.split('\n') if ':' in line]
+lind_numbers.sort()
+host_numbers = [int(line.split(':')[1]) for line in host_result.split('\n') if ':' in line]
+host_numbers.sort()
+
+if lind_numbers != host_numbers:
+    print "Numbers don't match"
+    exit(-1)
+
 if "fail" in lind_result or "fail" in host_result:
     print "Certain failure occured"
     exit(-1)

--- a/tests/test_cases/shutdown.py
+++ b/tests/test_cases/shutdown.py
@@ -1,0 +1,10 @@
+#!/bin/python2
+# Checks if any failure occurs
+import sys
+
+lind_result = sys.argv[1]
+host_result = sys.argv[2]
+
+if "fail" in lind_result or "fail" in host_result:
+    print "Certain failure occured"
+    exit(-1)

--- a/tests/test_cases/shutdown_fork.c
+++ b/tests/test_cases/shutdown_fork.c
@@ -1,3 +1,4 @@
+/* Test if shutdown() would take longer to run in a multi-process program */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/test_cases/shutdown_fork.c
+++ b/tests/test_cases/shutdown_fork.c
@@ -10,6 +10,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <time.h>
+#include <errno.h>
 
 int main(int argc, char *argv[]) {
 	int server_fd, new_socket, client_fd; 
@@ -25,14 +26,14 @@ int main(int argc, char *argv[]) {
 	// Open a pipe for syncing between parent and child process
 	if (pipe(parent_to_child) < 0)
 	{
-		printf("Failed to initialize parent to child pipe");
+		printf("Failed to initialize parent to child pipe: %n\n", strerror(errno));
 		fflush(stdout);
 		exit(EXIT_FAILURE);
 	}
 
 	// Create server socket, which we use to test shutdown
 	if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-		printf("server socket failed\n");
+		printf("server socket failed: %s\n", strerror(errno));
 		fflush(stdout);
 		exit(EXIT_FAILURE);
 	}
@@ -43,14 +44,14 @@ int main(int argc, char *argv[]) {
 
 		// Create a client socket
 		if ((client_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-			printf("client socket failed\n");
+			printf("client socket failed: %s\n", strerror(errno));
 			fflush(stdout);
 			exit(EXIT_FAILURE);
 		}
 
 		// Set client socket options
 		if (setsockopt(client_fd, SOL_SOCKET, SO_REUSEADDR, &opt2, sizeof(opt2))) {
-			printf("client setsockopt failed\n");
+			printf("client setsockopt failed: %s\n", strerror(errno));
 			fflush(stdout);
 			exit(EXIT_FAILURE);
 		}
@@ -60,14 +61,14 @@ int main(int argc, char *argv[]) {
 
 		// Set the server address
 		if (inet_pton(AF_INET, "127.0.0.1", &serv_addr.sin_addr) <= 0) {
-			printf("inet_pton failed\n");
+			printf("client inet_pton failed: %s\n", strerror(errno));
 			fflush(stdout);
 			exit(EXIT_FAILURE);
 		}
 
 		// Connect to server
 		if (connect(client_fd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {
-			printf("client connection failed\n");
+			printf("client connection failed: %s\n", strerror(errno));
 			fflush(stdout);
 			exit(EXIT_FAILURE);
 		}
@@ -99,7 +100,7 @@ int main(int argc, char *argv[]) {
 
 		// Set server socket option
 		if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt))) {
-			printf("server setsockopt failed\n");
+			printf("server setsockopt failed: %s\n", strerror(errno));
 			fflush(stdout);
 			exit(EXIT_FAILURE);
 		}
@@ -110,21 +111,21 @@ int main(int argc, char *argv[]) {
 
 		// Bind server socket to the address
 		if (bind(server_fd, (struct sockaddr*)&address, sizeof(address)) < 0) {
-			printf("server bind failed\n");
+			printf("server bind failed: %s\n", strerror(errno));
 			fflush(stdout);
 			exit(EXIT_FAILURE);
 		}
 
 		// Start listening
 		if (listen(server_fd, 3) < 0) {
-			printf("server listen failed\n");
+			printf("server listen failed: %s\n", strerror(errno));
 			fflush(stdout);
 			exit(EXIT_FAILURE);
 		}
 
 		// Receiving a new connection from child process
 		if ((new_socket = accept(server_fd, (struct sockaddr*)&address, (socklen_t*)&addrlen)) < 0) {
-			printf("server accept failed\n");
+			printf("server accept failed: %s\n", strerror(errno));
 			fflush(stdout);
 			exit(EXIT_FAILURE);
 		}

--- a/tests/test_cases/shutdown_fork.py
+++ b/tests/test_cases/shutdown_fork.py
@@ -1,0 +1,12 @@
+#!/bin/python2
+# Checks if any failure occurs
+import sys
+
+lind_result = sys.argv[1]
+host_result = sys.argv[2]
+
+if lind_result.replace('.', '0').isdigit() and host_result.replace('.', '0').isdigit() and float(lind_result) < 1:
+    exit(0)
+else:
+    print "Test case failed"
+    exit(1)

--- a/tests/test_cases/socketepoll.c
+++ b/tests/test_cases/socketepoll.c
@@ -275,5 +275,6 @@ int main() {
     pthread_join(clientthread1, NULL);
     pthread_join(serverthread, NULL);
     pthread_barrier_destroy(&syncbarrier);
+    pthread_barrier_destroy(&closebarrier);
     return 0;
 }

--- a/tests/test_cases/socketepoll.c
+++ b/tests/test_cases/socketepoll.c
@@ -19,6 +19,7 @@
 #define FALSE            0
 
 pthread_barrier_t closebarrier;
+pthread_barrier_t syncbarrier;
 
 void* client(void* v) { 
     int sock = 0, valread; 
@@ -40,7 +41,7 @@ void* client(void* v) {
     // Convert IPv4 and IPv6 addresses from text to binary form 
     inet_pton(AF_INET, "127.0.0.1", &serv_addr.sin_addr);
 
-    sleep(1);
+    pthread_barrier_wait(&syncbarrier);
 
     connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
     send(sock , hello , strlen(hello) , 0 );
@@ -148,6 +149,8 @@ void* server(void* v) {
       perror("epoll_ctl error");
       exit(-1);
    }
+
+   pthread_barrier_wait(&syncbarrier);
 
    while(1) 
    {
@@ -265,9 +268,12 @@ void* server(void* v) {
 
 int main() {
     pthread_t serverthread, clientthread1;
+    
+    pthread_barrier_init(&syncbarrier, NULL, 2);
     pthread_create(&serverthread, NULL, server, NULL);
     pthread_create(&clientthread1, NULL, client, NULL);
     pthread_join(clientthread1, NULL);
     pthread_join(serverthread, NULL);
+    pthread_barrier_destroy(&syncbarrier);
     return 0;
 }

--- a/tests/test_cases/socketselect.c
+++ b/tests/test_cases/socketselect.c
@@ -337,6 +337,7 @@ int main() {
     pthread_join(clientthread1, NULL);
     pthread_join(serverthread, NULL);
     pthread_barrier_destroy(&syncbarrier);
+    pthread_barrier_destroy(&closebarrier);
     return 0;
 }
 


### PR DESCRIPTION
This PR adds two nondeterministic test cases for `shutdown()`. `shutdown.c` has one thread called `ponger` and two threads called `pinger` and they keep incrementing values and bounce around between `ponger`. `shutdown_fork.c` tests whether it takes `shutdown` longer than 1 sec to run if it tries to shutdown a socket in a child process while the parent process is doing a blocking read from the same socket.