### PR TITLE
Feature/flock test

### DIFF
--- a/tests/applications/busybox/include/linux/netfilter/xt_connmark.h
+++ b/tests/applications/busybox/include/linux/netfilter/xt_connmark.h
@@ -1,42 +1,7 @@
-/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
-#ifndef _XT_CONNMARK_H
-#define _XT_CONNMARK_H
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef _XT_CONNMARK_H_target
+#define _XT_CONNMARK_H_target
 
-#include <linux/types.h>
+#include <linux/netfilter/xt_connmark.h>
 
-/* Copyright (C) 2002,2004 MARA Systems AB <http://www.marasystems.com>
- * by Henrik Nordstrom <hno@marasystems.com>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- */
-
-enum {
-	XT_CONNMARK_SET = 0,
-	XT_CONNMARK_SAVE,
-	XT_CONNMARK_RESTORE
-};
-
-enum {
-	D_SHIFT_LEFT = 0,
-	D_SHIFT_RIGHT,
-};
-
-struct xt_connmark_tginfo1 {
-	__u32 ctmark, ctmask, nfmask;
-	__u8 mode;
-};
-
-struct xt_connmark_tginfo2 {
-	__u32 ctmark, ctmask, nfmask;
-	__u8 shift_dir, shift_bits, mode;
-};
-
-struct xt_connmark_mtinfo1 {
-	__u32 mark, mask;
-	__u8 invert;
-};
-
-#endif /*_XT_CONNMARK_H*/
+#endif /*_XT_CONNMARK_H_target*/

--- a/tests/applications/busybox/include/linux/netfilter/xt_dscp.h
+++ b/tests/applications/busybox/include/linux/netfilter/xt_dscp.h
@@ -1,32 +1,27 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
-/* x_tables module for matching the IPv4/IPv6 DSCP field
+/* x_tables module for setting the IPv4/IPv6 DSCP field
  *
  * (C) 2002 Harald Welte <laforge@gnumonks.org>
+ * based on ipt_FTOS.c (C) 2000 by Matthew G. Marsh <mgm@paktronix.com>
  * This software is distributed under GNU GPL v2, 1991
  *
  * See RFC2474 for a description of the DSCP field within the IP Header.
  *
- * xt_dscp.h,v 1.3 2002/08/05 19:00:21 laforge Exp
+ * xt_DSCP.h,v 1.7 2002/03/14 12:03:13 laforge Exp
 */
-#ifndef _XT_DSCP_H
-#define _XT_DSCP_H
-
+#ifndef _XT_DSCP_TARGET_H
+#define _XT_DSCP_TARGET_H
+#include <linux/netfilter/xt_dscp.h>
 #include <linux/types.h>
 
-#define XT_DSCP_MASK	0xfc	/* 11111100 */
-#define XT_DSCP_SHIFT	2
-#define XT_DSCP_MAX	0x3f	/* 00111111 */
-
-/* match info */
-struct xt_dscp_info {
+/* target info */
+struct xt_DSCP_info {
 	__u8 dscp;
-	__u8 invert;
 };
 
-struct xt_tos_match_info {
-	__u8 tos_mask;
+struct xt_tos_target_info {
 	__u8 tos_value;
-	__u8 invert;
+	__u8 tos_mask;
 };
 
-#endif /* _XT_DSCP_H */
+#endif /* _XT_DSCP_TARGET_H */

--- a/tests/applications/busybox/include/linux/netfilter/xt_mark.h
+++ b/tests/applications/busybox/include/linux/netfilter/xt_mark.h
@@ -1,16 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
-#ifndef _XT_MARK_H
-#define _XT_MARK_H
+#ifndef _XT_MARK_H_target
+#define _XT_MARK_H_target
 
-#include <linux/types.h>
+#include <linux/netfilter/xt_mark.h>
 
-struct xt_mark_tginfo2 {
-	__u32 mark, mask;
-};
-
-struct xt_mark_mtinfo1 {
-	__u32 mark, mask;
-	__u8 invert;
-};
-
-#endif /*_XT_MARK_H*/
+#endif /*_XT_MARK_H_target */

--- a/tests/applications/busybox/include/linux/netfilter/xt_rateest.h
+++ b/tests/applications/busybox/include/linux/netfilter/xt_rateest.h
@@ -1,39 +1,17 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
-#ifndef _XT_RATEEST_MATCH_H
-#define _XT_RATEEST_MATCH_H
+#ifndef _XT_RATEEST_TARGET_H
+#define _XT_RATEEST_TARGET_H
 
 #include <linux/types.h>
 #include <linux/if.h>
 
-enum xt_rateest_match_flags {
-	XT_RATEEST_MATCH_INVERT	= 1<<0,
-	XT_RATEEST_MATCH_ABS	= 1<<1,
-	XT_RATEEST_MATCH_REL	= 1<<2,
-	XT_RATEEST_MATCH_DELTA	= 1<<3,
-	XT_RATEEST_MATCH_BPS	= 1<<4,
-	XT_RATEEST_MATCH_PPS	= 1<<5,
-};
-
-enum xt_rateest_match_mode {
-	XT_RATEEST_MATCH_NONE,
-	XT_RATEEST_MATCH_EQ,
-	XT_RATEEST_MATCH_LT,
-	XT_RATEEST_MATCH_GT,
-};
-
-struct xt_rateest_match_info {
-	char			name1[IFNAMSIZ];
-	char			name2[IFNAMSIZ];
-	__u16		flags;
-	__u16		mode;
-	__u32		bps1;
-	__u32		pps1;
-	__u32		bps2;
-	__u32		pps2;
+struct xt_rateest_target_info {
+	char			name[IFNAMSIZ];
+	__s8			interval;
+	__u8		ewma_log;
 
 	/* Used internally by the kernel */
-	struct xt_rateest	*est1 __attribute__((aligned(8)));
-	struct xt_rateest	*est2 __attribute__((aligned(8)));
+	struct xt_rateest	*est __attribute__((aligned(8)));
 };
 
-#endif /* _XT_RATEEST_MATCH_H */
+#endif /* _XT_RATEEST_TARGET_H */

--- a/tests/applications/busybox/include/linux/netfilter/xt_tcpmss.h
+++ b/tests/applications/busybox/include/linux/netfilter/xt_tcpmss.h
@@ -1,12 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
-#ifndef _XT_TCPMSS_MATCH_H
-#define _XT_TCPMSS_MATCH_H
+#ifndef _XT_TCPMSS_H
+#define _XT_TCPMSS_H
 
 #include <linux/types.h>
 
-struct xt_tcpmss_match_info {
-    __u16 mss_min, mss_max;
-    __u8 invert;
+struct xt_tcpmss_info {
+	__u16 mss;
 };
 
-#endif /*_XT_TCPMSS_MATCH_H*/
+#define XT_TCPMSS_CLAMP_PMTU 0xffff
+
+#endif /* _XT_TCPMSS_H */

--- a/tests/applications/busybox/include/linux/netfilter_ipv4/ipt_ecn.h
+++ b/tests/applications/busybox/include/linux/netfilter_ipv4/ipt_ecn.h
@@ -1,16 +1,34 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
-#ifndef _IPT_ECN_H
-#define _IPT_ECN_H
+/* Header file for iptables ipt_ECN target
+ *
+ * (C) 2002 by Harald Welte <laforge@gnumonks.org>
+ *
+ * This software is distributed under GNU GPL v2, 1991
+ * 
+ * ipt_ECN.h,v 1.3 2002/05/29 12:17:40 laforge Exp
+*/
+#ifndef _IPT_ECN_TARGET_H
+#define _IPT_ECN_TARGET_H
 
-#include <linux/netfilter/xt_ecn.h>
-#define ipt_ecn_info xt_ecn_info
+#include <linux/types.h>
+#include <linux/netfilter/xt_DSCP.h>
 
-enum {
-	IPT_ECN_IP_MASK       = XT_ECN_IP_MASK,
-	IPT_ECN_OP_MATCH_IP   = XT_ECN_OP_MATCH_IP,
-	IPT_ECN_OP_MATCH_ECE  = XT_ECN_OP_MATCH_ECE,
-	IPT_ECN_OP_MATCH_CWR  = XT_ECN_OP_MATCH_CWR,
-	IPT_ECN_OP_MATCH_MASK = XT_ECN_OP_MATCH_MASK,
+#define IPT_ECN_IP_MASK	(~XT_DSCP_MASK)
+
+#define IPT_ECN_OP_SET_IP	0x01	/* set ECN bits of IPv4 header */
+#define IPT_ECN_OP_SET_ECE	0x10	/* set ECE bit of TCP header */
+#define IPT_ECN_OP_SET_CWR	0x20	/* set CWR bit of TCP header */
+
+#define IPT_ECN_OP_MASK		0xce
+
+struct ipt_ECN_info {
+	__u8 operation;	/* bitset of operations */
+	__u8 ip_ect;	/* ECT codepoint of IPv4 header, pre-shifted */
+	union {
+		struct {
+			__u8 ece:1, cwr:1; /* TCP ECT bits */
+		} tcp;
+	} proto;
 };
 
-#endif /* IPT_ECN_H */
+#endif /* _IPT_ECN_TARGET_H */

--- a/tests/applications/busybox/include/linux/netfilter_ipv4/ipt_ttl.h
+++ b/tests/applications/busybox/include/linux/netfilter_ipv4/ipt_ttl.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
-/* IP tables module for matching the value of the TTL
- * (C) 2000 by Harald Welte <laforge@gnumonks.org> */
+/* TTL modification module for IP tables
+ * (C) 2000 by Harald Welte <laforge@netfilter.org> */
 
 #ifndef _IPT_TTL_H
 #define _IPT_TTL_H
@@ -8,14 +8,14 @@
 #include <linux/types.h>
 
 enum {
-	IPT_TTL_EQ = 0,		/* equals */
-	IPT_TTL_NE,		/* not equals */
-	IPT_TTL_LT,		/* less than */
-	IPT_TTL_GT,		/* greater than */
+	IPT_TTL_SET = 0,
+	IPT_TTL_INC,
+	IPT_TTL_DEC
 };
 
+#define IPT_TTL_MAXMODE	IPT_TTL_DEC
 
-struct ipt_ttl_info {
+struct ipt_TTL_info {
 	__u8	mode;
 	__u8	ttl;
 };

--- a/tests/applications/busybox/include/linux/netfilter_ipv6/ip6t_hl.h
+++ b/tests/applications/busybox/include/linux/netfilter_ipv6/ip6t_hl.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
-/* ip6tables module for matching the Hop Limit value
+/* Hop Limit modification module for ip6tables
  * Maciej Soltysiak <solt@dns.toxicfilms.tv>
- * Based on HW's ttl module */
+ * Based on HW's TTL module */
 
 #ifndef _IP6T_HL_H
 #define _IP6T_HL_H
@@ -9,14 +9,14 @@
 #include <linux/types.h>
 
 enum {
-	IP6T_HL_EQ = 0,		/* equals */
-	IP6T_HL_NE,		/* not equals */
-	IP6T_HL_LT,		/* less than */
-	IP6T_HL_GT,		/* greater than */
+	IP6T_HL_SET = 0,
+	IP6T_HL_INC,
+	IP6T_HL_DEC
 };
 
+#define IP6T_HL_MAXMODE	IP6T_HL_DEC
 
-struct ip6t_hl_info {
+struct ip6t_HL_info {
 	__u8	mode;
 	__u8	hop_limit;
 };

--- a/tests/test_cases/access.c
+++ b/tests/test_cases/access.c
@@ -1,0 +1,41 @@
+#undef _GNU_SOURCE
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main() {
+  int file_perm = S_IRUSR | S_IWUSR; // set file permissions
+  int fd = creat("create_foo.txt", file_perm);
+  if (fd == -1) {
+    perror("ERROR WITH CREATE");
+    exit(EXIT_FAILURE);
+  }
+  close(fd);
+  printf("Created fd %d\n", fd);
+
+  // Check if file exists
+  int access_result = access("create_foo.txt", F_OK);
+  if (access_result == -1) {
+    perror("COULD NOT ACCESS FILE");
+    exit(EXIT_FAILURE);
+  }
+  printf("File exists\n");
+
+  // Check if file permissions are valid
+  access_result = access("create_foo.txt", R_OK | W_OK);
+  if (access_result == -1) {
+    perror("INVALID PERMISSIONS FOR FILE");
+    exit(EXIT_FAILURE);
+  }
+  printf("File has the right permissions\n");
+
+  // Cleanup
+  remove("create_foo.txt");
+  fflush(stdout);
+  return 0;
+}

--- a/tests/test_cases/dettests.txt
+++ b/tests/test_cases/dettests.txt
@@ -34,3 +34,4 @@ fchmod.c
 truncate.c
 mutex.c
 socketpair.c
+flock.c

--- a/tests/test_cases/flock.c
+++ b/tests/test_cases/flock.c
@@ -9,6 +9,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+// Helper function to remove a file
 int remove_file(char file_name[]) {
   int rm = remove(file_name);
   if (rm == -1) {
@@ -19,8 +20,8 @@ int remove_file(char file_name[]) {
 }
 
 int main(int argc, char **argv) {
-  // Open a file to use
-  char file_name[100] = "flock.txt";
+  // Create a temporary file to use
+  char file_name[100] = "testfiles/flock.txt";
   int fd = open(file_name, O_RDWR | O_CREAT, 0777);
   if (fd == -1) {
     perror("OPEN FAILED\n");
@@ -70,7 +71,7 @@ int main(int argc, char **argv) {
   // Close file before removing
   close(fd);
 
-  // Remove the file
+  // Remove the temporary file
   remove(file_name);
   return 0;
 }

--- a/tests/test_cases/flock.c
+++ b/tests/test_cases/flock.c
@@ -1,0 +1,76 @@
+#undef _GNU_SOURCE
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int remove_file(char file_name[]) {
+  int rm = remove(file_name);
+  if (rm == -1) {
+    perror("FAILED TO REMOVE FILE\n");
+    exit(EXIT_FAILURE);
+  }
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  // Open a file to use
+  char file_name[100] = "flock.txt";
+  int fd = open(file_name, O_RDWR | O_CREAT, 0777);
+  if (fd == -1) {
+    perror("OPEN FAILED\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // Get an exclusive lock on the file
+  int lock = flock(fd, LOCK_EX);
+  if (lock == -1) {
+    perror("FAILED TO GET EXCLUSIVE LOCK\n");
+    close(fd);
+    remove_file(file_name);
+    exit(EXIT_FAILURE);
+  }
+  printf("Obtained exclusive lock on file\n");
+
+  // Release the exclusive lock on the file
+  lock = flock(fd, LOCK_UN);
+  if (lock == -1) {
+    perror("FAILED TO RELEASE EXCLUSIVE LOCK\n");
+    close(fd);
+    remove_file(file_name);
+    exit(EXIT_FAILURE);
+  }
+  printf("Released exclusive lock on file\n");
+
+  // Get a shared lock on the file
+  lock = flock(fd, LOCK_SH);
+  if (lock == -1) {
+    perror("FAILED TO GET SHARED LOCK\n");
+    close(fd);
+    remove_file(file_name);
+    exit(EXIT_FAILURE);
+  }
+  printf("Obtained shared lock on file\n");
+
+  // Release the shared lock on the file
+  lock = flock(fd, LOCK_UN);
+  if (lock == -1) {
+    perror("FAILED TO RELEASE SHARED LOCK\n");
+    close(fd);
+    remove_file(file_name);
+    exit(EXIT_FAILURE);
+  }
+  printf("Released shared lock on file\n");
+
+  // Close file before removing
+  close(fd);
+
+  // Remove the file
+  remove(file_name);
+  return 0;
+}

--- a/tests/test_cases/fstatfs.c
+++ b/tests/test_cases/fstatfs.c
@@ -1,0 +1,33 @@
+#undef _GNU_SOURCE
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/statfs.h>
+
+int main(int argc, char **argv) {
+  // Open the file first
+  char file_name[100] = "testfiles/fstatfsfile.txt";
+  int fd = open(file_name, O_RDONLY);
+  if (fd == -1) {
+    perror("Error opening file for statfs\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // fstatfs
+  struct statfs buf = {0};
+  if (fstatfs(file_name, &buf) == -1) {
+    perror("Error in fstatfs\n");
+    close(fd);
+    exit(EXIT_FAILURE);
+  }
+  close(fd);
+
+  // expected output is: NFS_SUPER_MAGIC 0x6969 on native CentOS 7 on CIMS
+  printf("filesystem type: %d\n", buf.f_type);
+  fflush(stdout);
+  return 0;
+}

--- a/tests/test_cases/getifaddrs.c
+++ b/tests/test_cases/getifaddrs.c
@@ -1,0 +1,37 @@
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+  struct ifaddrs *ifaddr, *ifa;
+  int family;
+  char host[INET6_ADDRSTRLEN];
+
+  if (getifaddrs(&ifaddr) == -1) {
+    perror("getifaddrs");
+    exit(EXIT_FAILURE);
+  }
+
+  for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == NULL)
+      continue;
+
+    family = ifa->ifa_addr->sa_family;
+
+    printf("%-8s %s (%d)\n", ifa->ifa_name,
+           (family == AF_PACKET)  ? "AF_PACKET"
+           : (family == AF_INET)  ? "AF_INET"
+           : (family == AF_INET6) ? "AF_INET6"
+                                  : "???",
+           family);
+  }
+
+  fflush(stdout);
+  freeifaddrs(ifaddr);
+  exit(EXIT_SUCCESS);
+}

--- a/tests/test_cases/getppid.c
+++ b/tests/test_cases/getppid.c
@@ -1,0 +1,17 @@
+#undef _GNU_SOURCE
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(void) {
+  puts("printing pid");
+
+  printf("%d\n", getppid());
+  perror("");
+  puts("getppid() succeeded");
+
+  return 0;
+}

--- a/tests/test_cases/getsockname.c
+++ b/tests/test_cases/getsockname.c
@@ -140,7 +140,7 @@ void *ponger(void *vargp) {
     // Test functions
     test_getpeername(new_socket);
     test_getsockname(new_socket);
-    test_getsockopt(new_socket);
+    // test_getsockopt(new_socket);
 
     close(new_socket);
   }

--- a/tests/test_cases/getsockname.c
+++ b/tests/test_cases/getsockname.c
@@ -1,0 +1,244 @@
+/* A multithreaded testcase for shutdown() and socket functions */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+pthread_barrier_t barrier;
+
+const int NUM_OF_PINGER = 2;
+const int NUM_OF_PINGPONG = 10;
+const int BUFFER_SIZE = 32;
+
+void clear_buffer(char *buffer, int length) {
+  for (int i = 0; i < length; ++i) {
+    buffer[i] = 0;
+  }
+}
+
+void test_getpeername(int socket_fd) {
+  struct sockaddr_storage addr;
+  socklen_t addr_len = sizeof(addr);
+  char ipstr[INET6_ADDRSTRLEN];
+
+  if (getpeername(socket_fd, (struct sockaddr *)&addr, &addr_len) == -1) {
+    perror("getpeername");
+    exit(EXIT_FAILURE);
+  }
+
+  if (addr.ss_family == AF_INET) {
+    struct sockaddr_in *s = (struct sockaddr_in *)&addr;
+    inet_ntop(AF_INET, &(s->sin_addr), ipstr, INET_ADDRSTRLEN);
+    printf("getpeername: IPv4 address: %s\n", ipstr);
+  } else { // AF_INET6
+    struct sockaddr_in6 *s = (struct sockaddr_in6 *)&addr;
+    inet_ntop(AF_INET6, &(s->sin6_addr), ipstr, INET6_ADDRSTRLEN);
+    printf("getpeername: IPv6 address: %s\n", ipstr);
+  }
+}
+
+void test_getsockname(int socket_fd) {
+  struct sockaddr_storage addr;
+  socklen_t addr_len = sizeof(addr);
+  char ipstr[INET6_ADDRSTRLEN];
+
+  if (getsockname(socket_fd, (struct sockaddr *)&addr, &addr_len) == -1) {
+    perror("getsockname");
+    exit(EXIT_FAILURE);
+  }
+
+  if (addr.ss_family == AF_INET) {
+    struct sockaddr_in *s = (struct sockaddr_in *)&addr;
+    inet_ntop(AF_INET, &(s->sin_addr), ipstr, INET_ADDRSTRLEN);
+    printf("getsockname: IPv4 address: %s\n", ipstr);
+  } else { // AF_INET6
+    struct sockaddr_in6 *s = (struct sockaddr_in6 *)&addr;
+    inet_ntop(AF_INET6, &(s->sin6_addr), ipstr, INET6_ADDRSTRLEN);
+    printf("getsockname: IPv6 address: %s\n", ipstr);
+  }
+}
+
+void test_getsockopt(int socket_fd) {
+  int option_value;
+  socklen_t option_len = sizeof(option_value);
+
+  if (getsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value,
+                 &option_len) == -1) {
+    perror("getsockopt");
+    exit(EXIT_FAILURE);
+  }
+
+  printf("getsockopt: Socket reuse addr flag: %d\n", option_value);
+}
+
+// Adapted from https://www.geeksforgeeks.org/socket-programming-cc/
+void *ponger(void *vargp) {
+  int server_fd, new_socket, valread, finished;
+  int opt = 1;
+  struct sockaddr_in address;
+  int addrlen = sizeof(address);
+  char buffer[BUFFER_SIZE];
+
+  // Create server socket
+  if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+    perror("ponger socket failed");
+    exit(EXIT_FAILURE);
+  }
+
+  // Set server socket option
+  if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt))) {
+    perror("ponger setsockopt failed");
+    exit(EXIT_FAILURE);
+  }
+
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = INADDR_ANY;
+  address.sin_port = htons(5000);
+
+  // Bind server socket to the address
+  if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+    perror("ponger bind failed");
+    exit(EXIT_FAILURE);
+  }
+
+  // Start listening
+  if (listen(server_fd, 3) < 0) {
+    perror("ponger listen failed");
+    exit(EXIT_FAILURE);
+  }
+
+  pthread_barrier_wait(&barrier);
+
+  // Bounce and increment numbers between pingers
+  for (int i = 0; i < NUM_OF_PINGER * NUM_OF_PINGPONG; ++i) {
+    // Establish a new connection
+    if ((new_socket = accept(server_fd, (struct sockaddr *)&address,
+                             (socklen_t *)&addrlen)) < 0) {
+      perror("ponger accept failed");
+      exit(EXIT_FAILURE);
+    }
+
+    // Receive a value from a pinger
+    clear_buffer(buffer, BUFFER_SIZE);
+    valread = read(new_socket, buffer, BUFFER_SIZE);
+    printf("ponger receive: %s\n", buffer);
+    fflush(stdout);
+
+    // Increment the value by 1 and send it back
+    sprintf(buffer, "%d", atoi(buffer) + 1);
+    send(new_socket, buffer, strlen(buffer), 0);
+    printf("ponger send: %s\n", buffer);
+    fflush(stdout);
+
+    // Test functions
+    test_getpeername(new_socket);
+    test_getsockname(new_socket);
+    test_getsockopt(new_socket);
+
+    close(new_socket);
+  }
+
+  shutdown(server_fd, SHUT_RDWR);
+  close(server_fd);
+}
+
+void *pinger(void *vargp) {
+  int pinger_id = *((int *)vargp);
+  int sock = 0, valread, client_fd;
+  int opt = 1;
+  int counter = 0;
+  struct sockaddr_in serv_addr;
+  char buffer[BUFFER_SIZE];
+
+  pthread_barrier_wait(&barrier);
+
+  // Loop a few times to try trigger race conditions
+  for (int i = 0; i < NUM_OF_PINGPONG; ++i) {
+    // Create a pinger socket
+    if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+      perror("pinger socket failed");
+      exit(EXIT_FAILURE);
+    }
+
+    // Set pinger socket options
+    if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt))) {
+      perror("pinger setsockopt failed");
+      exit(EXIT_FAILURE);
+    }
+
+    serv_addr.sin_family = AF_INET;
+    serv_addr.sin_port = htons(5000);
+
+    // Set the address
+    if (inet_pton(AF_INET, "127.0.0.1", &serv_addr.sin_addr) <= 0) {
+      perror("pinger inet_pton failed");
+      exit(EXIT_FAILURE);
+    }
+
+    // Connect to ponger
+    if ((client_fd = connect(sock, (struct sockaddr *)&serv_addr,
+                             sizeof(serv_addr))) < 0) {
+      perror("pinger connection failed");
+      exit(EXIT_FAILURE);
+    }
+
+    // Increment the current number by 1 and send it to ponger
+    clear_buffer(buffer, BUFFER_SIZE);
+    sprintf(buffer, "%d", ++counter);
+    printf("client %d send: %s\n", pinger_id, buffer);
+    fflush(stdout);
+    send(sock, buffer, strlen(buffer), 0);
+
+    // Call shutdown(). Not the way it's supposed to be used, but good enough
+    // for testing purpose
+    shutdown(sock, SHUT_WR);
+
+    // Read the incremented number from ponger
+    clear_buffer(buffer, BUFFER_SIZE);
+    valread = read(sock, buffer, BUFFER_SIZE);
+    counter = atoi(buffer);
+    printf("client %d receive: %s\n", pinger_id, buffer);
+    fflush(stdout);
+
+    close(sock);
+  }
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t ponger_id, pinger_id[NUM_OF_PINGER];
+  int pinger_id_natural[NUM_OF_PINGER];
+  for (int i = 0; i < NUM_OF_PINGER; ++i) {
+    pinger_id_natural[i] = i;
+  }
+
+  pthread_barrier_init(&barrier, NULL, NUM_OF_PINGER + 1);
+
+  printf("Starting Ponger\n");
+  fflush(stdout);
+  pthread_create(&ponger_id, NULL, ponger, NULL);
+
+  for (int i = 0; i < NUM_OF_PINGER; ++i) {
+    printf("Starting Pinger %d\n", i);
+    fflush(stdout);
+    pthread_create(&pinger_id[i], NULL, pinger, (void *)&pinger_id_natural[i]);
+  }
+
+  pthread_join(ponger_id, NULL);
+  for (int i = 0; i < NUM_OF_PINGER; ++i) {
+    pthread_join(pinger_id[i], NULL);
+  }
+
+  printf("Threads end\n");
+  fflush(stdout);
+
+  pthread_barrier_destroy(&barrier);
+
+  return 0;
+}

--- a/tests/test_cases/mknod.c
+++ b/tests/test_cases/mknod.c
@@ -1,0 +1,26 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+int main() {
+  mode_t mode = S_IFIFO | 0666;
+
+  if (mknod("namedpipe", mode, 0) == -1) {
+    perror("mknod");
+    exit(EXIT_FAILURE);
+  }
+
+  printf("Named pipe created successfully.\n");
+
+  if (unlink("namedpipe") == -1) {
+    perror("unlink");
+    exit(EXIT_FAILURE);
+  }
+  printf("Unlinked named pipe.");
+
+  // Not testing using mknod to create a device file since major and minor
+  // numbers may change.
+  return 0;
+}

--- a/tests/test_cases/pipe2.c
+++ b/tests/test_cases/pipe2.c
@@ -1,0 +1,43 @@
+#undef _GNU_SOURCE
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(void) {
+  char str[4096] = {0};
+  int ret, fd[2];
+
+  if (pipe2(fd, 0) < 0) {
+    perror("pipe2()");
+    exit(EXIT_FAILURE);
+  }
+  printf("pipe2() ret: [%d, %d]\n", fd[0], fd[1]);
+
+  if ((ret = write(fd[1], "hi\n", 3)) < 0) {
+    printf("write(): %s\n", strerror(errno));
+    exit(EXIT_FAILURE);
+  }
+  printf("write() ret: %d\n", ret);
+
+  if ((ret = read(fd[0], str, 3)) < 0) {
+    printf("read(): %s\n", strerror(errno));
+    exit(EXIT_FAILURE);
+  }
+  printf("read() ret: %d\n", ret);
+
+  for (size_t i = 0; i < sizeof fd / sizeof *fd; i++) {
+    if (close(fd[i]) < 0) {
+      perror("close()");
+      exit(EXIT_FAILURE);
+    }
+  }
+  puts(str);
+
+  return 0;
+}

--- a/tests/test_cases/rmdir.c
+++ b/tests/test_cases/rmdir.c
@@ -1,0 +1,26 @@
+#undef _GNU_SOURCE
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  char dir_name[100] = "testfolder";
+  mode_t dir_per = (S_IRUSR | S_IWUSR);
+  if (mkdir(dir_name, dir_per) == -1) {
+    perror("mkdir");
+    exit(EXIT_FAILURE);
+  }
+  printf("Created directory successfully\n");
+  if (rmdir(dir_name) == -1) {
+    perror("rmdir");
+    exit(EXIT_FAILURE);
+  }
+  printf("Removed directory successfully\n");
+
+  fflush(stdout);
+  return 0;
+}

--- a/tests/test_cases/statfs.c
+++ b/tests/test_cases/statfs.c
@@ -8,17 +8,51 @@
 #include <string.h>
 #include <sys/statfs.h>
 
+#define EXPECTED_TYPE 0x6969
+
+void test_statfs(const char *file_name){
+  struct statfs buf = {0};
+
+  if (statfs(file_name, &buf) == -1) {
+    perror("Error in fstatfs");
+    printf("File: %s\n", file_name);
+    return;
+  }
+
+  printf("Testing file: %s\n", file_name);
+  printf("File system type: %d\n", buf.f_type);
+  printf("Total file system blocks: %ld\n", buf.f_blocks);
+  printf("Free blocks: %ld\n", buf.f_bfree);
+  printf("Total file system inodes: %ld\n", buf.f_files);
+  printf("Free inodes: %ld\n", buf.f_ffree);
+  fflush(stdout);
+
+  if (buf.f_type != EXPECTED_TYPE) {
+    printf("Unexpected file system type for file %s: expected %d, got %d\n",
+      file_name, EXPECTED_TYPE, buf.f_type);
+  }
+  
+}
+
 int main(int argc, char **argv) {
   char file_name[100] = "testfiles/statfsfile.txt";
 
-  // statfs
-  struct statfs buf = {0};
-  if (statfs(file_name, &buf) == -1) {
-    perror("Error in fstatfs\n");
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s <file1> <file2> ...\n", argv[0]);
     exit(EXIT_FAILURE);
   }
+
+  // statfs
+  // struct statfs buf = {0};
+  // if (statfs(file_name, &buf) == -1) {
+  //   perror("Error in fstatfs\n");
+  //   exit(EXIT_FAILURE);
+  // }
   // expected output is: NFS_SUPER_MAGIC 0x6969 on native CentOS 7 on CIMS
-  printf("filesystem type: %d", buf.f_type);
-  fflush(stdout);
-  return 0;
+  // printf("filesystem type: %d", buf.f_type);
+  // fflush(stdout);
+  for (int i = 1; i < argc; ++i) {
+    test_statfs(argv[i]);
+  }
+  return EXIT_SUCCESS;
 }

--- a/tests/test_cases/statfs.c
+++ b/tests/test_cases/statfs.c
@@ -1,0 +1,24 @@
+#undef _GNU_SOURCE
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/statfs.h>
+
+int main(int argc, char **argv) {
+  char file_name[100] = "testfiles/statfsfile.txt";
+
+  // statfs
+  struct statfs buf = {0};
+  if (statfs(file_name, &buf) == -1) {
+    perror("Error in fstatfs\n");
+    exit(EXIT_FAILURE);
+  }
+  // expected output is: NFS_SUPER_MAGIC 0x6969 on native CentOS 7 on CIMS
+  printf("filesystem type: %d", buf.f_type);
+  fflush(stdout);
+  return 0;
+}

--- a/tests/test_cases/testfiles/flock.txt
+++ b/tests/test_cases/testfiles/flock.txt
@@ -1,0 +1,1 @@
+Testfile for flock

--- a/tests/test_cases/testfiles/fstatfsfile.txt
+++ b/tests/test_cases/testfiles/fstatfsfile.txt
@@ -1,0 +1,1 @@
+Testfile for fstatfs

--- a/tests/test_cases/testfiles/statfsfile.txt
+++ b/tests/test_cases/testfiles/statfsfile.txt
@@ -1,0 +1,1 @@
+Testfile for statfs


### PR DESCRIPTION
## Description

This change adds a test for the `flock` syscall. It has also been added to the list of deterministic test cases in `dettests.txt`

While working on this test, two issues were found regarding the `flock`. PRs to fix both have been raised in their respective repositories.

- (Native Client) The dispatcher was not forwarding the arguments received by the function to RustPOSIX. (https://github.com/Lind-Project/native_client/pull/139)
- (RustPosix) Advisory Locks were not working as intended. (https://github.com/Lind-Project/safeposix-rust/pull/181)

**Both of them should be merged before merging this one.**

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
After making the changes associated with the aforementioned PRs, `make test-verbose` was run to ensure

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, safeposix-rust)
