### PR TITLE
Fast option for DEBUG_RUSTPOSIX

### DIFF
--- a/src/mklind
+++ b/src/mklind
@@ -387,10 +387,14 @@ function build_rustposix() {
 
 	print "Building RustPOSIX"
     cd "$LIND_BASE/src/safeposix-rust"
-    if [[ "$DEBUG_RUSTPOSIX" == "true" ]]; then 
+	if [[ "$DEBUG_RUSTPOSIX" == "true" ]]; then 
         cargo build
         cp "target/debug/librustposix.so"  "$LIND_ENV_PATH/librustposix.so"
         cp "target/debug/lind_fs_utils"  "$LIND_ENV_PATH_BIN/lind_fs_utils"
+    elif [[ "$DEBUG_RUSTPOSIX" == "fast" ]]; then 
+        RUSTFLAGS="-g" cargo build --release
+        cp "target/release/librustposix.so"  "$LIND_ENV_PATH/librustposix.so"
+        cp "target/release/lind_fs_utils"  "$LIND_ENV_PATH_BIN/lind_fs_utils"
     else
         cargo build --release
         cp "target/release/librustposix.so"  "$LIND_ENV_PATH/librustposix.so"


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->
Add another option to compile safeposix using `DEBUG_RUSTPOSIX=fast` which builds safeposix with symbols but is optimized.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Run `make` with option 3
## Checklist:

<!-- Add details about the checklist whenever needed -->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, safeposix-rust)
