### PR TITLE
Fix UDS tests after signal merge

### DIFF
--- a/tests/test_cases/dettests.txt
+++ b/tests/test_cases/dettests.txt
@@ -42,7 +42,6 @@ poll.c
 sem_forks.c
 uds-getsockname.c
 uds-nb-select.c
-uds-serverclient.c
 signal-simple.c
 signal-fork.c
 sigprocmask.c

--- a/tests/test_cases/nondet.txt
+++ b/tests/test_cases/nondet.txt
@@ -28,3 +28,4 @@ statfs.c
 pipe2.c
 getifaddrs.c
 uds-socketselect.c
+uds-serverclient.c

--- a/tests/test_cases/uds-serverclient.py
+++ b/tests/test_cases/uds-serverclient.py
@@ -1,5 +1,5 @@
 #!/bin/python2
-# Check if uds-socketselect.c runs correctly in native as it does within Lind
+# Check if uds-serverclient.c runs correctly in native as it does within Lind
 
 import re
 import sys
@@ -17,13 +17,6 @@ native_result_split = native_results.split('\n')
 if len(lind_result_split) != len(native_result_split):
     print "Mismatched number of lines!"
     exit(-1)
-
-# Replace specific fds in lines with *
-for i in range(len(lind_result_split)):
-    if lind_result_split[i].find("New incoming connection") != -1 or lind_result_split[i].find("Descriptor") != -1:
-        lind_result_split[i] = re.sub("\d", "*", lind_result_split[i])
-    if native_result_split[i].find("New incoming connection") != -1 or native_result_split[i].find("Descriptor") != -1:
-        native_result_split[i] = re.sub("\d", "*", native_result_split[i])
 
 # Check if same number of each line is contained in both lists
 if Counter(lind_result_split) != Counter(native_result_split):


### PR DESCRIPTION
## Description

Fixes https://github.com/Lind-Project/lind_project/issues/350
Fixes the test suite, all tests are successful now.

- Changed test `uds-serverclient` from deterministic to non-deterministic due to order of output being different within runs
- Added non-deterministic checks (python file) for `uds-serverclient`
- Changed `uds-socketselect` test to allow different order of outputs between lind and native output


### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Full test suite - Successful

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, safeposix-rust)
