### PR TITLE
chdir and fchdir test case fix

### DIFF
--- a/tests/test_cases/chdir_getcwd.py
+++ b/tests/test_cases/chdir_getcwd.py
@@ -18,7 +18,6 @@ host_init_cwd = host_result[0].split('::')[1] # Initial cwd
 host_res_cwd = host_result[1].split('::')[1] # Result cwd
 
 # The difference between them should be equal to regularoutput's. 
-# We add an extra / to lind, because as it's on the root directory, it will omit the first /.
 if lind_res_cwd.replace(lind_init_cwd,"/") != host_res_cwd.replace(host_init_cwd,""):
     print "The cwd's do not match!"
     exit(-1)

--- a/tests/test_cases/chdir_getcwd.py
+++ b/tests/test_cases/chdir_getcwd.py
@@ -21,3 +21,4 @@ host_res_cwd = host_result[1].split('::')[1] # Result cwd
 if lind_res_cwd.replace(lind_init_cwd,"/") != host_res_cwd.replace(host_init_cwd,""):
     print "The cwd's do not match!"
     exit(-1)
+    

--- a/tests/test_cases/fchdir.py
+++ b/tests/test_cases/fchdir.py
@@ -18,7 +18,6 @@ host_init_cwd = host_result[0].split('::')[1] # Initial cwd
 host_res_cwd = host_result[1].split('::')[1] # Result cwd
 
 # The difference between them should be equal to regularoutput's. 
-# We add an extra / to lind, because as it's on the root directory, it will omit the first /.
-if lind_res_cwd.replace(lind_init_cwd,"/") != host_res_cwd.replace(host_init_cwd,"") + "/":
+if lind_res_cwd.replace(lind_init_cwd,"/") != host_res_cwd.replace(host_init_cwd,""):
     print "The cwd's do not match!"
     exit(-1)


### PR DESCRIPTION
## Description

Fixes # (issue)

The current fchdir_syscall implementation uses convpath to update the current working directory, which appends a forward slash to the pathname (which should not be the case), while the implementation of chdir_syscall correctly wraps convpath inside normpath that helps to get rid of a "/" at the end of the pathname. Fixing fchdir_syscall by wrapping convpath inside normpath causes the fchdir.c test to fail because the test manually adds a "/" at the end to match the expected behavior of the original fchdir_syscall implementation. This PR fixes the test case by removing the unnecessary addition of a "/" and removing the misleading comments in chdir_getcwd.c and fchdir.c tests.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue.

## How Has This Been Tested?
This has been tested by updating fchdir.c test case and the implementation for fchdir_syscall and running both tests inside safeposix-rust and full lind test suite. All the tests pass.

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, safeposix-rust)
