### PR TITLE
GCC-4 compilation scripts fixes

### DIFF
--- a/tests/applications/gcc-4.4.3/lind-arch
+++ b/tests/applications/gcc-4.4.3/lind-arch
@@ -10,7 +10,7 @@ mv mpfr-3.1.2 mpfr
 cd ../
 mkdir build-gcc
 cd build-gcc/
-../gcc-4.4.3/configure CFLAGS='-fgnu89-inline -g -O2' CXXFLAGS='-fgnu89-inline -g -O2' --prefix=/usr/local/gcc-4.4.3/ --enable-checking=release --enable-languages=c,c++ --disable-multili
+../gcc-4.4.3/configure CC=gcc CFLAGS='-fgnu89-inline -g -O2' CXXFLAGS='-fgnu89-inline -g -O2' --prefix=/usr/local/gcc-4.4.3/ --enable-checking=release --enable-languages=c,c++ --disable-multili
 
 # Modify linux-unwind.h
 linuxfile="../gcc-4.4.3/gcc/config/i386/linux-unwind.h"
@@ -20,7 +20,7 @@ if [ ! -f "$linuxfile" ]; then
   exit 1
 fi
 
-temp_file2=$(mktemp)
+temp_file=$(mktemp)
 
 awk '{
   if (NR == 136) { print "siginfo_t *pinfo;" }
@@ -30,7 +30,7 @@ awk '{
   else { print $0 }
 }' "$linuxfile" > "$temp_file"
 
-mv "$temp_file2" "$linuxfile"
+mv "$temp_file" "$linuxfile"
 
 # Modify Makefile
 makefile_path="Makefile"
@@ -40,7 +40,7 @@ if [ ! -f "$makefile_path" ]; then
   exit 1
 fi
 
-temp_file=$(mktemp)
+temp_file2=$(mktemp)
 
 awk '{
   if ($1 == "CC" && $3 == "gcc") { print "CC = gcc -fgnu89-inline" }

--- a/tests/applications/gcc-4.4.3/lind-ubuntu
+++ b/tests/applications/gcc-4.4.3/lind-ubuntu
@@ -16,7 +16,8 @@ mv mpfr-3.1.2 mpfr
 cd ../
 mkdir build-gcc
 cd build-gcc/
-../gcc-4.4.3/configure CFLAGS='-fgnu89-inline -g -O2' CXXFLAGS='-fgnu89-inline -g -O2' --prefix=/usr/local/gcc-4.4.3/ --enable-checking=release --enable-languages=c,c++ --disable-multili
+../gcc-4.4.3/configure CC=gcc CFLAGS='-fgnu89-inline -g -O2' CXXFLAGS='-fgnu89-inline -g -O2' --prefix=/usr/local/gcc-4.4.3/ --enable-checking=release --enable-languages=c,c++ --disable-multili
+
 
 # Modify linux-unwind.h
 linuxfile="../gcc-4.4.3/gcc/config/i386/linux-unwind.h"
@@ -26,7 +27,7 @@ if [ ! -f "$linuxfile" ]; then
   exit 1
 fi
 
-temp_file2=$(mktemp)
+temp_file=$(mktemp)
 
 awk '{
   if (NR == 136) { print "siginfo_t *pinfo;" }
@@ -36,7 +37,7 @@ awk '{
   else { print $0 }
 }' "$linuxfile" > "$temp_file"
 
-mv "$temp_file2" "$linuxfile"
+mv "$temp_file" "$linuxfile"
 
 # Modify Makefile
 makefile_path="Makefile"
@@ -46,7 +47,7 @@ if [ ! -f "$makefile_path" ]; then
   exit 1
 fi
 
-temp_file=$(mktemp)
+temp_file2=$(mktemp)
 
 awk '{
   if ($1 == "CC" && $3 == "gcc") { print "CC = gcc -fgnu89-inline" }


### PR DESCRIPTION
## Description

When compiling GCC-4 in the Sphere, gcc-7 was detected and used for compilation, but on the server, gcc (version 9) was automatically used for testing. This led to failures in modifying the Makefile to pass the necessary flags, resulting in gcc compilation failure. 

I also found several typos in gcc compilation scripts.. Accidentally those typos fix problem from another way so the compilation successes when I tested on local server. 

This PR is to fix the above problems.

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Testing

Tested on lind-archlinux and Lind-ubuntu on lind server

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, safeposix-rust)
